### PR TITLE
Fix for Colors when mod is disabled/uninstalled

### DIFF
--- a/dev-module.json
+++ b/dev-module.json
@@ -3,7 +3,7 @@
     "title": "Dynamic Illumination (DEV)",
     "description": "Adds additional setting for lighting time of day color, additional lighting 'times' (Dawn/Dusk), and make scene lighting impact global illumination setting.",
     "author": "delVhar",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "minimumCoreVersion": "0.6.4",
     "compatibleCoreVersion": "0.6.4",
     "scripts": ["scripts/dynamic-illumination.js"],

--- a/dev-module.json
+++ b/dev-module.json
@@ -3,7 +3,7 @@
     "title": "Dynamic Illumination (DEV)",
     "description": "Adds additional setting for lighting time of day color, additional lighting 'times' (Dawn/Dusk), and make scene lighting impact global illumination setting.",
     "author": "delVhar",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "minimumCoreVersion": "0.6.4",
     "compatibleCoreVersion": "0.6.4",
     "scripts": ["scripts/dynamic-illumination.js"],

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "Dynamic Illumination",
     "description": "Adds additional setting for lighting time of day color, additional lighting 'times' (Dawn/Dusk), and make scene lighting impact global illumination setting.",
     "author": "delVhar",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "minimumCoreVersion": "0.6.4",
     "compatibleCoreVersion": "0.6.4",
     "scripts": ["scripts/dynamic-illumination.js"],

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "Dynamic Illumination",
     "description": "Adds additional setting for lighting time of day color, additional lighting 'times' (Dawn/Dusk), and make scene lighting impact global illumination setting.",
     "author": "delVhar",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "minimumCoreVersion": "0.6.4",
     "compatibleCoreVersion": "0.6.4",
     "scripts": ["scripts/dynamic-illumination.js"],

--- a/scripts/dynamic-illumination.js
+++ b/scripts/dynamic-illumination.js
@@ -165,17 +165,6 @@ Hooks.on('getSceneControlButtons', controls => {
 
 Hooks.once("init", () => 
 {
-    canvas.scene.unsetFlag("core","darknessColor");  // Delete darknessColor Flag to clean up old usage.
-
-    // Set Canvas Darkness color to match flag
-    var color = canvas.scene.getFlag("dynamic-illumination","darknessColor");
-    if(color == undefined)
-    {
-        canvas.scene.setFlag("dynamic-illumination","darknessColor", "#110033");
-        color = "#110033";
-    }
-    CONFIG.Canvas.darknessColor = color;
-
     game.settings.register("dynamic-illumination", "linkGlobalLight", {
 		name: game.i18n.localize("dynamic-illumination.linkGlobalLight.name"),
 		hint: game.i18n.localize("dynamic-illumination.linkGlobalLight.hint"),
@@ -308,5 +297,16 @@ Hooks.once("init", () =>
 		type: Number,
         range: {min: 0.0, max: 1.0, step: 0.05}
     });
+
+
+    canvas.scene.unsetFlag("core","darknessColor");  // Delete darknessColor Flag to clean up old usage.
+    // Set Canvas Darkness color to match flag
+    var color = canvas.scene.getFlag("dynamic-illumination","darknessColor");
+    if(color == undefined)
+    {
+        canvas.scene.setFlag("dynamic-illumination","darknessColor", "#110033");
+        color = "#110033";
+    }
+    CONFIG.Canvas.darknessColor = color;
     
 });

--- a/scripts/dynamic-illumination.js
+++ b/scripts/dynamic-illumination.js
@@ -30,8 +30,9 @@ function changeLighting(level, color)
         }
         else if(canvas.scene.data.darkness == 0) // We are at 0, so first change color then get darker.
         {
-            canvas.scene.setFlag("core","darknessColor", color).then(()=> {
+            canvas.scene.setFlag("dynamic-illumination","darknessColor", color).then(()=> {
                 canvas.scene.update({darkness: level}, {animateDarkness: true}).then(() => {
+                    CONFIG.Canvas.darknessColor = color;
                     canvas.getLayer("LightingLayer").update();
                 });            
             });
@@ -41,7 +42,8 @@ function changeLighting(level, color)
             canvas.scene.update({darkness: level}, {animateDarkness: true, diff: false}).then(
                 setTimeout(() => {
                     //canvas.scene.setFlag("core","darknessColor", color)
-                    canvas.scene.setFlag("core","darknessColor", color).then(()=> {
+                    canvas.scene.setFlag("dynamic-illumination","darknessColor", color).then(()=> {
+                        CONFIG.Canvas.darknessColor = color;
                         canvas.getLayer("LightingLayer").update();
                     });
                 },game.settings.get("dynamic-illumination","animationColorChangeDelay") * 1000)        
@@ -50,8 +52,9 @@ function changeLighting(level, color)
     }
     else
     {
-        canvas.scene.setFlag("core","darknessColor", color).then(()=> {
+        canvas.scene.setFlag("dynamic-illumination","darknessColor", color).then(()=> {
             canvas.scene.update({darkness: level}, {animateDarkness: false}).then(() => {
+                CONFIG.Canvas.darknessColor = color;
                 canvas.getLayer("LightingLayer").update();
             });            
         });
@@ -69,18 +72,20 @@ async function interpolateSceneColor(target="#FFFEFF")
         name: "lighting.darknessColor",
         duration: game.settings.get("dynamic-illumination","animationColorChangeDelay") * 1000,
         ontick: (dt, attributes) => {
-            color = interpolateColor(canvas.scene.getFlag("core","darknessColor"), target, attributes[0].parent.interpolationSteps/attributes[0].to)
+            color = interpolateColor(canvas.scene.getFlag("dynamic-illumination","darknessColor"), target, attributes[0].parent.interpolationSteps/attributes[0].to)
             // Only update if we actually changed color
-            if(color.toLowerCase() != canvas.scene.getFlag("core","darknessColor").toLowerCase())
+            if(color.toLowerCase() != canvas.scene.getFlag("dynamic-illumination","darknessColor").toLowerCase())
             {                
-                canvas.scene.setFlag("core","darknessColor", color).then(()=> {
+                canvas.scene.setFlag("dynamic-illumination","darknessColor", color).then(()=> {
+                    CONFIG.Canvas.darknessColor = color;
                     canvas.getLayer("LightingLayer").update();
                 });
             } 
         }
     }).then(() => {
          //Set it to the target at the end in case it wasn't there for some reason
-         canvas.scene.setFlag("core","darknessColor", color).then(()=> {
+         canvas.scene.setFlag("dynamic-illumination","darknessColor", color).then(()=> {
+            CONFIG.Canvas.darknessColor = color;
             canvas.getLayer("LightingLayer").update();
         });
     }); }
@@ -158,7 +163,18 @@ Hooks.on('getSceneControlButtons', controls => {
 
 });
 
-Hooks.once("init", () => {
+Hooks.once("init", () => 
+{
+    canvas.scene.unsetFlag("core","darknessColor");  // Delete darknessColor Flag to clean up old usage.
+
+    // Set Canvas Darkness color to match flag
+    var color = canvas.scene.getFlag("dynamic-illumination","darknessColor");
+    if(color == undefined)
+    {
+        canvas.scene.setFlag("dynamic-illumination","darknessColor", "#110033");
+        color = "#110033";
+    }
+    CONFIG.Canvas.darknessColor = color;
 
     game.settings.register("dynamic-illumination", "linkGlobalLight", {
 		name: game.i18n.localize("dynamic-illumination.linkGlobalLight.name"),

--- a/scripts/dynamic-illumination.js
+++ b/scripts/dynamic-illumination.js
@@ -298,7 +298,9 @@ Hooks.once("init", () =>
         range: {min: 0.0, max: 1.0, step: 0.05}
     });
 
+})
 
+Hooks.once("canvasInit", () => {
     canvas.scene.unsetFlag("core","darknessColor");  // Delete darknessColor Flag to clean up old usage.
     // Set Canvas Darkness color to match flag
     var color = canvas.scene.getFlag("dynamic-illumination","darknessColor");
@@ -307,6 +309,5 @@ Hooks.once("init", () =>
         canvas.scene.setFlag("dynamic-illumination","darknessColor", "#110033");
         color = "#110033";
     }
-    CONFIG.Canvas.darknessColor = color;
-    
+    CONFIG.Canvas.darknessColor = color;    
 });


### PR DESCRIPTION
Now using a custom flag that updates the darknessColor Config, rather than setting the core darknessColor flag.
This will mean darknessColor resets to Foundry defaults if the module is removed/disabled
Fixes #8 
